### PR TITLE
Ensure proper UTF-8 output

### DIFF
--- a/lib/facter/log4jscanner.rb
+++ b/lib/facter/log4jscanner.rb
@@ -21,14 +21,14 @@ Facter.add('log4jscanner') do
         warnings['scan_file_time'] = 'Scan file has not been updated in 10 days'
       end
 
-      vulnerable_jars = File.readlines(scan_file).map { |l| l.strip }.reject { |l| l.empty? }
+      vulnerable_jars = File.readlines(scan_file).map { |l| l.strip.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') }.reject { |l| l.empty? }
     else
       warnings['scan_file'] = 'Scan file not found, vulnerable jars information invalid'
     end
 
     error_file = cache_dir + '/scan_errors'
     if File.file?(error_file)
-      errors = File.readlines(error_file).map { |l| l.strip }.reject { |l| l.empty? }
+      errors = File.readlines(error_file).map { |l| l.strip.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') }.reject { |l| l.empty? }
     end
 
     data['vulnerable_jars'] = vulnerable_jars


### PR DESCRIPTION
Puppet HATES invalid UTF-8 and entirely dies on it. As we may not have any influence on path/filenames,
and they may well contain invalid utf-8, we have to deal with it. This is just removing them.