### PR TITLE
Fix Windows fact upload in scan script

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,9 @@ class log4jscanner (
 
   case $facts['kernel'] {
     'Linux': {
-      $fact_upload_cmd = "/opt/puppetlabs/bin/puppet facts upload --environment ${environment}"
+      $puppet_bin = '/opt/puppetlabs/bin/puppet'
+      $fact_upload_params = "facts upload --environment ${environment}"
+      $fact_upload_cmd = "${puppet_bin} ${fact_upload_params}"
       $cache_dir = '/opt/puppetlabs/log4jscanner'
       $scan_script = 'scan_data_generation.sh'
       $scan_script_mode = '0700'
@@ -111,7 +113,9 @@ class log4jscanner (
       }
     }
     'Darwin': {
-      $fact_upload_cmd = "/opt/puppetlabs/bin/puppet facts upload --environment ${environment}"
+      $puppet_bin = '/opt/puppetlabs/bin/puppet'
+      $fact_upload_params = "facts upload --environment ${environment}"
+      $fact_upload_cmd = "${puppet_bin} ${fact_upload_params}"
       $cache_dir = '/opt/puppetlabs/log4jscanner'
       $scan_script = 'scan_data_generation.sh'
       $scan_script_mode = '0700'
@@ -150,7 +154,9 @@ class log4jscanner (
       }
     }
     'windows': {
-      $fact_upload_cmd = "\"${windows_puppet_install_path}\\bin\\puppet.bat\" facts upload --environment ${environment}"
+      $puppet_bin = "${windows_puppet_install_path}\\bin\\puppet.bat"
+      $fact_upload_params = "facts upload --environment ${environment}"
+      $fact_upload_cmd = "\"${puppet_bin}\" ${fact_upload_params}"
       $cache_dir = 'C:/ProgramData/PuppetLabs/log4jscanner'
       $scan_script = 'scan_data_generation.ps1'
       $scan_script_mode = '0770'
@@ -201,11 +207,12 @@ class log4jscanner (
   }
 
   $template_data = {
-    'directories'     => $dirs,
-    'skip'            => $skip_dirs,
-    'cache_dir'       => $cache_dir,
-    'fact_upload_cmd' => $fact_upload_cmd,
-    'scan_bin'        => $scan_bin,
+    'directories'        => $dirs,
+    'skip'               => $skip_dirs,
+    'cache_dir'          => $cache_dir,
+    'puppet_bin'         => $puppet_bin,
+    'fact_upload_params' => $fact_upload_params,
+    'scan_bin'           => $scan_bin,
   }
   file { $scan_cmd:
     ensure  => $ensure_file,

--- a/templates/scan_data_generation.ps1.epp
+++ b/templates/scan_data_generation.ps1.epp
@@ -118,8 +118,12 @@ function Invoke-Scan {
   $diff = (Compare-Object $scanFileContents $scanFilePreviousContents)
   if ($diff) {
     Write-Host "Uploading fact"
-    $fact_cmd = "<%= regsubst($fact_upload_cmd,'"','`"','G') %>"
-    & $fact_cmd --color=false
+    $cmd = "<%= $puppet_bin %>"
+    $params = $()
+    <% split($fact_upload_params, ' ').each |$p| { %>
+    $params += "<%= $p %>"
+    <% } %>
+    Start-Process -FilePath $cmd -ArgumentList $params -NoNewWindow -Wait
   }
 }
 

--- a/templates/scan_data_generation.sh.epp
+++ b/templates/scan_data_generation.sh.epp
@@ -36,7 +36,7 @@ diff=$(diff -y --suppress-common "${UPDATEFILE}" "${UPDATEFILE}.previous" | wc -
 rm -f "${UPDATEFILE}.previous"
 if [ "${diff}" != "0" ]; then
   logger -p info -t scan_data_generation.sh "Uploading fact"
-  <%= $fact_upload_cmd %> 2>/dev/null 1>/dev/null
+  <%= $puppet_bin %> <%= $fact_upload_params %> 2>/dev/null 1>/dev/null
 fi
 logger -p info -t scan_data_generation.sh "Log4jscanner scan data refreshed"
 


### PR DESCRIPTION
Not quite sure how this was working before. The method I was using before to call Puppet to upload facts when vulnerable_jars changed didn't like spaces in the path. This modifies the template to take the binary and parameters separately so we can use Start-Process instead.