### PR TITLE
(maint) Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-@nmburgan
-@binford2k
+* @nmburgan @binford2k


### PR DESCRIPTION
This was previously formatted incorrectly. This change ensures that the repo has
full codepath coverage and that owners get pinged on PRs.