### PR TITLE
Do not hardcode used environment in template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class log4jscanner (
   case $facts['kernel'] {
     'Linux': {
       $puppet_bin = '/opt/puppetlabs/bin/puppet'
-      $fact_upload_params = "facts upload --environment ${environment}"
+      $fact_upload_params = "facts upload"
       $fact_upload_cmd = "${puppet_bin} ${fact_upload_params}"
       $cache_dir = '/opt/puppetlabs/log4jscanner'
       $scan_script = 'scan_data_generation.sh'

--- a/spec/classes/log4jscanner_spec.rb
+++ b/spec/classes/log4jscanner_spec.rb
@@ -6,7 +6,7 @@ describe 'log4jscanner' do
     context "on #{os}" do
       case os_facts[:kernel]
       when 'Linux'
-        let(:fact_upload_cmd) { '/opt/puppetlabs/bin/puppet facts upload --environment production' }
+        let(:fact_upload_cmd) { '/opt/puppetlabs/bin/puppet facts upload' }
         let(:cache_dir) { '/opt/puppetlabs/log4jscanner' }
         let(:scan_script) { 'scan_data_generation.sh' }
         let(:scan_script_mode) { '0700' }

--- a/templates/scan_data_generation.sh.epp
+++ b/templates/scan_data_generation.sh.epp
@@ -36,7 +36,19 @@ diff=$(diff -y --suppress-common "${UPDATEFILE}" "${UPDATEFILE}.previous" | wc -
 rm -f "${UPDATEFILE}.previous"
 if [ "${diff}" != "0" ]; then
   logger -p info -t scan_data_generation.sh "Uploading fact"
-  <%= $puppet_bin %> <%= $fact_upload_params %> 2>/dev/null 1>/dev/null
+  # Find environment puppet runs in. As it is entirely possible to have puppet agent run by external
+  # tools calling it - and them always telling puppet in which environment, a simple config print
+  # for environment can be wrong.
+  # So we parse the report of the last run and use that.
+  # In case that fails to parse or does not exist yet, we fall back to asking puppet.
+  # The awk BEGIN/END part is magic to make awk exit with an error, if match wasn't found (say, empty file).
+  lastreport=$(puppet config print lastrunreport)
+  if [ -f "${lastreport}" ]; then
+      environment=$(awk -F ': ' 'BEGIN { rc=1 } /^environment: / { print $2; rc=0; exit } END { exit rc }' ${lastreport} || puppet config print environment )
+  else
+      environment=$(puppet config print environment)
+  fi
+  <%= $puppet_bin %> <%= $fact_upload_params %> --environment ${environment} 2>/dev/null 1>/dev/null
 fi
 logger -p info -t scan_data_generation.sh "Log4jscanner scan data refreshed"
 


### PR DESCRIPTION
This avoids triggering the notify (and as such a long log4jscanner
run) on file changes just because one puppet run is in a different
environment (say, for testing).

To allow this, we have to find the environment used in the script.
We first parse the last runs report (if exists), and if that fails we
fall back to directly asking puppet what it thinks. This way we
support both, standard environments and those that somewhat drive
around the normal mechanism of setting the environment for the agent.

This Fixes #16 