### PR TITLE
Add a parameter to skip initial scans

### DIFF
--- a/lib/facter/log4jscanner.rb
+++ b/lib/facter/log4jscanner.rb
@@ -35,6 +35,7 @@ Facter.add('log4jscanner') do
     data['vulnerable_jars_count'] = vulnerable_jars.count
     data['errors'] = errors
     data['last_scan'] = last_runtime
+    data['warnings'] = warnings
     data
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,7 +225,9 @@ class log4jscanner (
   }
 
   unless $skip_initial_scan {
-    File[$scan_cmd] ~> Exec[$generate_scan_data_exec]
+    if $generate_scan_data_exec {
+      File[$scan_cmd] ~> Exec[$generate_scan_data_exec]
+    }
   }
 
   if $fact_upload_exec {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@
 # @param cron_monthday
 # @param cron_weekday
 # @param cron_minute
+# @param skip_initial_scan
+#   If this parameter is set, then the scan data won't be generated until the cron job gets to it
 # @param windows_directories
 #   Which directories to scan on Windows nodes
 # @param windows_skip
@@ -36,6 +38,7 @@ class log4jscanner (
   $cron_monthday                     = absent,
   $cron_weekday                      = absent,
   $cron_minute                       = fqdn_rand(59),
+  Boolean $skip_initial_scan         = false,
   Array[String] $windows_directories = ['C:'],
   Array[String] $windows_skip        = ['C:\Windows\Temp'],
   Integer $scheduled_task_every      = 1,
@@ -219,7 +222,10 @@ class log4jscanner (
     mode    => $scan_script_mode,
     content => epp("${module_name}/${scan_script}.epp", $template_data),
     require => File[$scan_bin],
-    notify  => Exec[$generate_scan_data_exec],
+  }
+
+  unless $skip_initial_scan {
+    File[$scan_cmd] ~> Exec[$generate_scan_data_exec]
   }
 
   if $fact_upload_exec {

--- a/spec/classes/log4jscanner_spec.rb
+++ b/spec/classes/log4jscanner_spec.rb
@@ -52,7 +52,6 @@ describe 'log4jscanner' do
             .with_mode(scan_script_mode)
             .with_content(default_script_regex)
             .with_require("File[#{scan_bin}]")
-            .with_notify('Exec[Log4jscanner generate scan data]')
           is_expected.to contain_exec('Log4jscanner fact upload')
             .with_command(fact_upload_cmd)
             .with_path(['/usr/bin', '/bin', '/sbin', '/usr/local/bin', cache_dir])


### PR DESCRIPTION
There are some use cases, such as changing environments where you may
not want the first scan to happen during the Puppet run. This gives you
that option.

Fixes #16